### PR TITLE
Feature - Remove inconfigurable child SVG fill attribute

### DIFF
--- a/src/@types/metadata-definition.d.ts
+++ b/src/@types/metadata-definition.d.ts
@@ -1,5 +1,0 @@
-declare interface MetadataDefinition {
-  name: string;
-  children: MetadataDefinition[];
-  value: string;
-}

--- a/src/@types/svgson.d.ts
+++ b/src/@types/svgson.d.ts
@@ -4,5 +4,15 @@ declare module 'svgson' {
 }
 
 declare interface ParsedSvg {
-  children: any[];
+  children: ParsedSvgChild[];
+}
+
+declare interface ParsedSvgChild {
+  name: string;
+  type: string;
+  value: string;
+  attributes: {
+    [key: string]: string;
+  };
+  children: ParsedSvgChild[];
 }


### PR DESCRIPTION
Fixes #1 by recursively removing the `fill` attribute from SVG children so they always inherit the fill of the Framer component.